### PR TITLE
chore: add language attributes for github linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+tests/resources/**/*.properties.expected linguist-language=properties
+tests/resources/**/*.properties.in linguist-language=properties
+tests/resources/**/*.xml.expected linguist-language=xml
+tests/resources/**/*.xml.in linguist-language=xml


### PR DESCRIPTION
This will fix the lack of syntax highlighting for the test resources that have special file extensions.

| Before | After |
| -- | -- |
| ![image](https://github.com/stackabletech/config-utils/assets/10092581/1e696be1-c7a5-4f35-9b21-326d89ca1b80) | ![image](https://github.com/stackabletech/config-utils/assets/10092581/3167cdc4-731a-433c-b1a0-6a7bc9e1f3ab) |

> [!note]
> Linguist seems to trip up on umlauts in properties files.