### PR TITLE
chore: Bump rust-toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+
+- Bump rust-toolchain to 1.84.1 ([#11]).
+
+[#11]: https://github.com/stackabletech/config-utils/pull/11
+
 ## [0.2.0] - 2024-06-25
 
 ### Added

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.84.1"


### PR DESCRIPTION
The old toolchain was causing problems when run with Rust 1.84+

```
error: toolchain '1.78.0-x86_64-unknown-linux-gnu' is not installed
help: run `rustup toolchain install 1.78.0-x86_64-unknown-linux-gnu` to install it
```