### PR TITLE
chore: Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.3.0] - 2026-05-19
+## [0.4.0] - 2026-05-21
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "config-utils"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "rstest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "config-utils"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Stackable GmbH <info@stackable.tech>"]
 license = "Apache-2.0"
 edition = "2024"


### PR DESCRIPTION
0.3.0 was only released as a tag (but not in the Cargo.toml), so we actually need to release 0.4.0 instead of 0.3.0